### PR TITLE
Add HubSpot integration to contact form

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,6 +11,7 @@ declare global {
 				DB: D1Database;
 				RESEND_API_KEY: string;
 				EMAILS: string;
+				HUBSPOT_ACCESS_TOKEN: string;
 			};
 		}
 	}

--- a/src/routes/api/contact/+server.ts
+++ b/src/routes/api/contact/+server.ts
@@ -161,5 +161,33 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 		console.error('Resend email error:', err);
 	}
 
+	try {
+		const nameParts = name.trim().split(/\s+/);
+		const firstName = nameParts[0] || '';
+		const lastName = nameParts.slice(1).join(' ') || '';
+		const res = await fetch('https://api.hubapi.com/crm/v3/objects/contacts', {
+			method: 'POST',
+			headers: {
+				'Authorization': `Bearer ${platform!.env.HUBSPOT_ACCESS_TOKEN}`,
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				properties: {
+					firstname: firstName,
+					lastname: lastName,
+					email: email.trim(),
+					company: affiliation.trim(),
+					country: country.trim(),
+					...(message?.trim() ? { freeform_problem_statement: message.trim() } : {})
+				}
+			})
+		});
+		if (!res.ok) {
+			console.error('HubSpot API error:', res.status, await res.text());
+		}
+	} catch (err) {
+		console.error('HubSpot create contact error:', err);
+	}
+
 	return json({ success: true });
 };


### PR DESCRIPTION
## Summary
- Adds HubSpot contact creation on form submission (alongside existing D1 + Resend flow)
- Maps form fields to HubSpot properties: name → firstname/lastname, email, affiliation → company, country, message → freeform_problem_statement
- Requires `HUBSPOT_ACCESS_TOKEN` secret in Cloudflare (`npx wrangler secret put HUBSPOT_ACCESS_TOKEN`)

## Test plan
- [ ] Set `HUBSPOT_ACCESS_TOKEN` secret via wrangler
- [ ] Submit the contact form and verify contact appears in HubSpot
- [ ] Verify existing D1 insert and Resend email still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)